### PR TITLE
fix(server): ignore null strings as well when ignorable=true

### DIFF
--- a/server/src/main/kotlin/moe/yuuta/server/formprocessor/FormData.kt
+++ b/server/src/main/kotlin/moe/yuuta/server/formprocessor/FormData.kt
@@ -5,4 +5,7 @@ package moe.yuuta.server.formprocessor
 @Retention(AnnotationRetention.RUNTIME)
 annotation class FormData(val name: String,
                           val urlEncode: Boolean = false,
+                          // If it is true, the fields with default values (String: "", Number: 0) will be removed.
+                          // If it is false, the fields with default values will be kept as 'key=' or 'key=0', etc.
+                          // Nulls are always removed.
                           val ignorable: Boolean = true)

--- a/server/src/main/kotlin/moe/yuuta/server/formprocessor/HttpForm.kt
+++ b/server/src/main/kotlin/moe/yuuta/server/formprocessor/HttpForm.kt
@@ -17,6 +17,7 @@ object HttpForm {
             try {
                 var rawValue: Any? = field.get(obj)
                 if (rawValue == null) continue
+                if (data.ignorable && rawValue.toString() == "") continue
                 try {
                     if (rawValue.toString().toDouble() == "0".toDouble()) {
                         if (data.ignorable) continue

--- a/server/src/test/java/moe/yuuta/server/formprocessor/HttpFormTest.java
+++ b/server/src/test/java/moe/yuuta/server/formprocessor/HttpFormTest.java
@@ -10,7 +10,9 @@ public class HttpFormTest {
     public void shouldToBuffer() {
         assertEquals("normalString=haoye&" +
                         "normalInteger=123&" +
-                        "encodeString=+++Ri+kk+a",
+                        "encodeString=+++Ri+kk+a&" +
+                        "shouldNotIgnored=&" +
+                        "shouldNotIgnored2=0",
                 HttpForm.toBuffer(new SampleObject()).toString().trim());
         // Give the ignorable integer a value so it won't be ignored
         SampleObject sampleObject = new SampleObject();
@@ -18,7 +20,9 @@ public class HttpFormTest {
         assertEquals("normalString=haoye&" +
                         "normalInteger=123&" +
                         "encodeString=+++Ri+kk+a&" +
-                        "ignorableInteger=2333",
+                        "ignorableInteger=2333&" +
+                        "shouldNotIgnored=&" +
+                        "shouldNotIgnored2=0",
                 HttpForm.toBuffer(sampleObject).toString().trim());
     }
 }

--- a/server/src/test/java/moe/yuuta/server/formprocessor/SampleObject.java
+++ b/server/src/test/java/moe/yuuta/server/formprocessor/SampleObject.java
@@ -13,6 +13,21 @@ class SampleObject {
     @FormData(name = "ignorableInteger")
     private int ignorableInteger = 0;
 
+    @FormData(name = "shouldIgnored")
+    private String shouldIgnored = "";
+
+    @FormData(name = "shouldIgnored2")
+    private String shouldIgnored2 = null;
+
+    @FormData(name = "shouldIgnored3", ignorable = false)
+    private String shouldIgnored3 = null;
+
+    @FormData(name = "shouldNotIgnored", ignorable = false)
+    private String shouldNotIgnored = "";
+
+    @FormData(name = "shouldNotIgnored2", ignorable = false)
+    private int shouldNotIgnored2 = 0;
+
     public String getNormalString() {
         return normalString;
     }


### PR DESCRIPTION
It seems like the MiPush Server had an update sometimes before which started returning errors if 'extra.jobkey=' is present. This parameter was left blank intentionally but was not ignored before.

Signed-off-by: Trumeet <17158086+Trumeet@users.noreply.github.com>